### PR TITLE
fix namespace error on OAuth2Client

### DIFF
--- a/src/OAuth2Client.php
+++ b/src/OAuth2Client.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace DouglasResende\OAuth2Client;


### PR DESCRIPTION
- Fix the following error:
```
Namespace declaration statement has to be the very first statement or after any
declare call in line 4
```